### PR TITLE
Add PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Issue Description
+Clearly and concisely describe the issue.
+
+## Root cause
+(Optional) Briefly describe the root cause analysis of the problem. Feel free to leave blank if this PR is not a bugfix.
+
+## Solution
+Describe your code changes in detail.
+
+## Related Resource
+(Optional) Any related resource, eg. class diagram.
+
+## Result
+(Optional) Visualization of the results, eg. screenshot of the execution result of the sample input.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-## Issue Description
+## Feature/Bug Description
 Clearly and concisely describe the issue.
 
 ## Root cause
-(Optional) Briefly describe the root cause analysis of the problem. Feel free to leave blank if this PR is not a bugfix.
+(Optional) Briefly describe the root cause and analysis of the problem. Feel free to leave blank if this PR is not a bugfix.
 
 ## Solution
 Describe your code changes in detail.


### PR DESCRIPTION
## Feature Description
A template of PR description. The template is expected to automatically pop up in order to guide users to provide useful information in their PR description.

## Root Cause
I'm creating a PR to generate some descriptive screenshots for the Git/Github tutorial. Instead of pushing some meaningless changes, I've decided to create a PR description template in response to @liangnaiyun-tw and @skychocowhite 's suggestion.

## Solution
The template contains 5 sections: "Feature/Bug Description", "Root cause", "Solution", "Related Resource", and "Result". Brief descriptions are also added in the template.

## Related Resource
* Issue #11 
* Reference: https://www.gitkraken.com/blog/enhancing-pull-request-descriptions-templates